### PR TITLE
Used units changes in flcSysUtils.pas for FPC under UNIX compatibility

### DIFF
--- a/Source/Utils/flcSysUtils.pas
+++ b/Source/Utils/flcSysUtils.pas
@@ -71,8 +71,7 @@ uses
 {$IFDEF FREEPASCAL}
 {$IFDEF UNIX}
 uses
-  BaseUnix,
-  Unix;
+  SysUtils;
 {$ENDIF}
 {$ENDIF}
 


### PR DESCRIPTION
GetLastOSError in Free Pascal is declared in SysUtils unit.